### PR TITLE
Use 2 more caches for updating documents.

### DIFF
--- a/txn/txn.go
+++ b/txn/txn.go
@@ -424,7 +424,7 @@ func (r *Runner) PurgeMissing(collections ...string) error {
 			logf("WARNING: purging from document %s/%v the missing transaction ids %v", collection, tdoc.DocId, idsList)
 			err := c.UpdateId(tdoc.DocId, M{"$pull": M{"txn-queue": M{"$in": idsList}}})
 			if err != nil {
-				return fmt.Errorf("error purging missing transaction %s: %v", txnId.Hex(), err)
+				return fmt.Errorf("error purging missing transaction %v: %v", idsList, err)
 			}
 		}
 		if err := iter.Close(); err != nil {

--- a/txn/txn.go
+++ b/txn/txn.go
@@ -421,7 +421,13 @@ func (r *Runner) PurgeMissing(collections ...string) error {
 			for fullTxnId, _ := range idsToRemove {
 				idsList = append(idsList, fullTxnId)
 			}
-			logf("WARNING: purging from document %s/%v the missing transaction ids %v", collection, tdoc.DocId, idsList)
+			var info string
+			if len(idsList) < 5 {
+				info = fmt.Sprintf("the missing transaction ids %v", idsList)
+			} else {
+				info = fmt.Sprintf("%d missing transaction ids", len(idsList))
+			}
+			logf("WARNING: purging from document %s/%v %s", collection, tdoc.DocId, info)
 			err := c.UpdateId(tdoc.DocId, M{"$pull": M{"txn-queue": M{"$in": idsList}}})
 			if err != nil {
 				return fmt.Errorf("error purging missing transaction %v: %v", idsList, err)

--- a/txn/txn.go
+++ b/txn/txn.go
@@ -389,6 +389,7 @@ func (r *Runner) PurgeMissing(collections ...string) error {
 	}
 
 	found := make(map[bson.ObjectId]bool)
+	knownMissing := make(map[bson.ObjectId]bool)
 	colls := make(map[string]bool)
 
 	sort.Strings(collections)
@@ -397,20 +398,33 @@ func (r *Runner) PurgeMissing(collections ...string) error {
 		iter := c.Find(nil).Select(bson.M{"_id": 1, "txn-queue": 1}).Iter()
 		var tdoc TDoc
 		for iter.Next(&tdoc) {
+			idsToRemove := make(map[string]bool)
 			for _, fullTxnId := range tdoc.TxnIds {
 				txnId := bson.ObjectIdHex(fullTxnId[:24])
 				if found[txnId] {
 					continue
 				}
-				if r.tc.FindId(txnId).One(nil) == nil {
-					found[txnId] = true
-					continue
+				if !knownMissing[txnId] {
+					if r.tc.FindId(txnId).One(nil) == nil {
+						found[txnId] = true
+						continue
+					}
+					knownMissing[txnId] = true
 				}
-				logf("WARNING: purging from document %s/%v the missing transaction id %s", collection, tdoc.DocId, txnId)
-				err := c.UpdateId(tdoc.DocId, M{"$pull": M{"txn-queue": M{"$regex": "^" + txnId.Hex() + "_*"}}})
-				if err != nil {
-					return fmt.Errorf("error purging missing transaction %s: %v", txnId.Hex(), err)
-				}
+				// We queue the full TXN id not just the prefix.
+				idsToRemove[fullTxnId] = true
+			}
+			if len(idsToRemove) == 0 {
+				continue
+			}
+			idsList := make([]string, 0, len(idsToRemove))
+			for fullTxnId, _ := range idsToRemove {
+				idsList = append(idsList, fullTxnId)
+			}
+			logf("WARNING: purging from document %s/%v the missing transaction ids %v", collection, tdoc.DocId, idsList)
+			err := c.UpdateId(tdoc.DocId, M{"$pull": M{"txn-queue": M{"$in": idsList}}})
+			if err != nil {
+				return fmt.Errorf("error purging missing transaction %s: %v", txnId.Hex(), err)
 			}
 		}
 		if err := iter.Close(); err != nil {


### PR DESCRIPTION
Instead of updating the document once for each transaction Id, queue up all the transaction Ids in the document
that are going to need to be updated, and then use set removal to actually get rid of them.
Also cache knownMissing transaction ids, so we don't have to lookup every transaction that is missing
on every document that is missing it.
